### PR TITLE
feat: update Paper convention to 26.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ plugins {
 
 The consumer Gradle project can request a higher paper or velocity version, but **not** a lower one.
 
-- The current Paper version: 1.21.11-R0.1-SNAPSHOT
+- The current Paper version: 26.1.2.build.63-stable
 - The current Velocity version: 3.4.0-SNAPSHOT
 - The current Minestom version: 2026.01.08-1.21.11
 
@@ -90,8 +90,8 @@ The consumer Gradle project can request a higher paper or velocity version, but 
 // Example for Override
 
 dependencies {
-    // This will override the current version with 1.21.12-R0.1-SNAPSHOT
-    compileOnly("io.papermc.paper:paper-api:1.21.12-R0.1-SNAPSHOT")
+    // This will override the current version with a newer Paper build
+    compileOnly("io.papermc.paper:paper-api:26.1.2.build.+")
 }
 ```
 
@@ -117,8 +117,8 @@ If a newer paper or velocity version is required, it can just be added to the de
 // Example for Override
 
 dependencies {
-    // This will override the current version with 1.21.12-R0.1-SNAPSHOT
-    compileOnly("io.papermc.paper:paper-api:1.21.12-R0.1-SNAPSHOT") 
+    // This will override the current version with a newer Paper build
+    compileOnly("io.papermc.paper:paper-api:26.1.2.build.+")
 }
 ```
 

--- a/src/main/kotlin/gg/grounds/base-conventions.gradle.kts
+++ b/src/main/kotlin/gg/grounds/base-conventions.gradle.kts
@@ -1,8 +1,6 @@
 package gg.grounds
 
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     id("com.diffplug.spotless")
@@ -11,15 +9,6 @@ plugins {
 }
 
 kotlin { jvmToolchain(25) }
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_24
-    targetCompatibility = JavaVersion.VERSION_24
-}
-
-tasks.withType<JavaCompile>().configureEach { options.release.set(24) }
-
-tasks.withType<KotlinCompile>().configureEach { compilerOptions.jvmTarget.set(JvmTarget.JVM_24) }
 
 tasks.test {
     useJUnitPlatform()

--- a/src/main/kotlin/gg/grounds/paper-conventions.gradle.kts
+++ b/src/main/kotlin/gg/grounds/paper-conventions.gradle.kts
@@ -4,7 +4,7 @@ plugins { id("gg.grounds.paper-base-conventions") }
 
 repositories { maven("https://repo.papermc.io/repository/maven-public/") }
 
-dependencies { compileOnly("io.papermc.paper:paper-api:1.21.11-R0.1-SNAPSHOT") }
+dependencies { compileOnly("io.papermc.paper:paper-api:26.1.2.build.63-stable") }
 
 val pluginVersion: Any = project.version
 


### PR DESCRIPTION
# Pull Request

## Description
Updates the shared Paper convention plugin to use Paper API 26.1.2 build 63. Because Paper 26.1.2 requires Java 25 metadata, base conventions keep the Java/Kotlin toolchain on 25. The old explicit Java/Kotlin target 24 workaround was for Gradle issue #35204 and is no longer needed on Gradle 9.5.0.

The README now documents the new Paper version format and uses 26.1.2.build.+ in override examples.

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] ♻️ Refactoring
- [x] 📚 Documentation
- [ ] 🔧 Chore

## Related Issues
- N/A

## Testing
- [x] Unit tests pass: ./gradlew test
- [x] Manual testing completed: temporary consumer applied gg.grounds.base-conventions and compiled Java/Kotlin classes to class-file major version 69
- [ ] New tests added for new functionality

Additional validation:
- ./gradlew build --warning-mode all
- ./gradlew spotlessApply
- ./gradlew build

## Checklist
- [x] I have performed a self-review of my own code
- [x] Tests have been added/updated and pass (if needed)
- [x] Documentation has been updated (if needed)
